### PR TITLE
Dev - Set C locale in build scripts

### DIFF
--- a/builds/utilities/update-config-files.sh
+++ b/builds/utilities/update-config-files.sh
@@ -10,6 +10,8 @@
 
 echo "   Start update-config-files.sh execution..."
 
+export LC_ALL=C
+
 LP3D_ME=$(basename "$(test -L "$0" && readlink "$0" || echo "$0")")
 LP3D_CHANGE_DATE_LONG=`date +%a,\ %d\ %b\ %Y\ %H:%M:%S\ %z`
 LP3D_CHANGE_DATE=`date +%a\ %b\ %d\ %Y`


### PR DESCRIPTION
The `date` command produces different outputs depending on the user
locale; however, the Debian changelog is expected to be generated in the
C locale, otherwise it won't get parsed.

This was found in https://github.com/trevorsandy/lpub3d/issues/338